### PR TITLE
Fixes incorrect constant in altitude calculation for traffic reports. 

### DIFF
--- a/app/src/main/java/com/apps4av/avarehelper/connections/BufferProcessor.java
+++ b/app/src/main/java/com/apps4av/avarehelper/connections/BufferProcessor.java
@@ -215,7 +215,7 @@ public class BufferProcessor {
                         // invalid
                         continue;
                     }
-                    object.put("altitude", (double) altitude);
+                    object.put("altitude", (double)((OwnshipGeometricAltitudeMessage)m).mAltitudeWGS84);
                     object.put("time", (long) m.getTime());
                 } catch (JSONException e1) {
                     continue;

--- a/app/src/main/java/com/apps4av/avarehelper/gdl90/BasicReportMessage.java
+++ b/app/src/main/java/com/apps4av/avarehelper/gdl90/BasicReportMessage.java
@@ -196,7 +196,7 @@ public class BasicReportMessage extends Message {
         int codedAltitude = 0;
         codedAltitude  = ((int)msg[13] & 0xFF) << 4;
         codedAltitude += ((int)msg[14] & 0xF0) >> 4;
-        mAltitude = (codedAltitude * 25) - 1025;
+        mAltitude = (codedAltitude * 25) - 1000;
 
         mNic = (int)msg[14] & 0x04;
         

--- a/app/src/main/java/com/apps4av/avarehelper/gdl90/LongReportMessage.java
+++ b/app/src/main/java/com/apps4av/avarehelper/gdl90/LongReportMessage.java
@@ -196,7 +196,7 @@ public class LongReportMessage extends Message {
         int codedAltitude = 0;
         codedAltitude  = ((int)msg[13] & 0xFF) << 4;
         codedAltitude += ((int)msg[14] & 0xF0) >> 4;
-        mAltitude = (codedAltitude * 25) - 1025;
+        mAltitude = (codedAltitude * 25) - 1000;
 
         mNic = (int)msg[14] & 0x04;
         

--- a/app/src/main/java/com/apps4av/avarehelper/gdl90/OwnshipMessage.java
+++ b/app/src/main/java/com/apps4av/avarehelper/gdl90/OwnshipMessage.java
@@ -33,7 +33,7 @@ public class OwnshipMessage extends Message {
     public int mHorizontalVelocity;
     public int mVerticalVelocity;
     
-    public int mAltitude;
+    public double mAltitude;
     
     boolean mIsTrackHeadingValid;
     boolean mIsTrackHeadingTrueTrackAngle;
@@ -78,7 +78,7 @@ public class OwnshipMessage extends Message {
             /*
              * In meters
              */
-            mAltitude = (int)((double)alt / 3.28084);
+            mAltitude = (double)alt / 3.28084;
         }
 
         /*


### PR DESCRIPTION
Causes traffic reports to report 25 feet low (before rounding error).
